### PR TITLE
Update eth_mnist.py

### DIFF
--- a/examples/mnist/eth_mnist.py
+++ b/examples/mnist/eth_mnist.py
@@ -49,7 +49,7 @@ parser.add_argument("--plot", dest="plot", action="store_true")
 parser.add_argument("--gpu", dest="gpu", action="store_true")
 parser.set_defaults(plot=False, gpu=False, train=True)
 
-args = parser.parse_args()
+args, _ = parser.parse_known_args()
 
 seed = args.seed
 n_neurons = args.n_neurons


### PR DESCRIPTION
While testing through running the code chunk by chunk through jupyter notebook, resolved issue where parse_args() would conflict with jupyter. A solution would be to use parse_known_args() rather than parse_args(), it also adds in the arguments properly and does not conflict with jupyter or other solutions.