### PR TITLE
Fix import for depreciated torch._six

### DIFF
--- a/bindsnet/datasets/collate.py
+++ b/bindsnet/datasets/collate.py
@@ -8,7 +8,14 @@ Modifications exist to have [time, batch, n_0, ... n_k] instead of batch in dime
 """
 
 import torch
-from torch._six import container_abcs, string_classes, int_classes
+
+# https://github.com/pytorch/pytorch/pull/94709#issuecomment-1461471006
+try:
+    from torch._six import container_abcs, string_classes, int_classes
+except ImportError:
+    int_classes = int
+    string_classes = str
+    import collections.abc as container_abcs
 
 from torch.utils.data._utils import collate as pytorch_collate
 

--- a/bindsnet/pipeline/base_pipeline.py
+++ b/bindsnet/pipeline/base_pipeline.py
@@ -2,7 +2,13 @@ import time
 from typing import Tuple, Dict, Any
 
 import torch
-from torch._six import container_abcs, string_classes
+
+# https://github.com/pytorch/pytorch/pull/94709#issuecomment-1461471006
+try:
+    from torch._six import container_abcs, string_classes
+except ImportError:
+    string_classes = str
+    import collections.abc as container_abcs
 
 from ..network import Network
 from ..network.monitors import Monitor


### PR DESCRIPTION
Fixes an import error for `torch._six`, as it was depreciated. See [https://github.com/pytorch/pytorch/pull/94709#issuecomment-1461471006](https://github.com/pytorch/pytorch/pull/94709#issuecomment-1461471006)